### PR TITLE
bump up BigQuery SDK to 0.30.0-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ScalikeJDBC extension for Google BigQuery
 ```scala
 libraryDependencies ++= Seq(
   "com.mayreh" %% "scalikejdbc-bigquery" % "0.0.6",
-  "com.google.cloud" % "google-cloud-bigquery" % "0.13.0-beta",
+  "com.google.cloud" % "google-cloud-bigquery" % "0.30.0-beta",
   "org.scalikejdbc" %% "scalikejdbc" % scalikejdbcVersion // specify scalikejdbc version you want. 
 )
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ configs(IntegrationTest)
 inConfig(IntegrationTest)(Defaults.itSettings)
 
 val scalikejdbcVersion = "3.0.0"
-val googleCloudVersion = "0.13.0-beta"
+val googleCloudVersion = "0.30.0-beta"
 
 libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc" % scalikejdbcVersion % "provided,it,test",

--- a/src/main/scala/scalikejdbc/QueryRequestBuilder.scala
+++ b/src/main/scala/scalikejdbc/QueryRequestBuilder.scala
@@ -2,8 +2,8 @@ package scalikejdbc
 
 import java.time.ZoneId
 
-import com.google.cloud.bigquery.{QueryParameterValue, QueryRequest}
-import scalikejdbc.bigquery.{Format, BqParameter, BqPreparedStatement}
+import com.google.cloud.bigquery.{QueryJobConfiguration, QueryParameterValue}
+import scalikejdbc.bigquery.{BqParameter, BqPreparedStatement, Format}
 
 import scala.collection.JavaConverters._
 
@@ -12,9 +12,9 @@ object QueryRequestBuilder {
   /**
    * Instantiate QueryRequestBuilder that SQL statement and parameters are set.
    */
-  def apply(statement: SQLSyntax): QueryRequest.Builder = {
+  def apply(statement: SQLSyntax): QueryJobConfiguration.Builder = {
 
-    val builder = QueryRequest.newBuilder(statement.value)
+    val builder = QueryJobConfiguration.newBuilder(statement.value)
     val ps = new BqPreparedStatement
 
     // almost same implementation as scalikejdbc.StatementExecutor

--- a/src/main/scala/scalikejdbc/bigquery/QueryExecutor.scala
+++ b/src/main/scala/scalikejdbc/bigquery/QueryExecutor.scala
@@ -1,6 +1,7 @@
 package scalikejdbc.bigquery
 
-import com.google.cloud.bigquery.{QueryResponse, BigQuery}
+import com.google.cloud.bigquery.BigQuery.{QueryOption, QueryResultsOption}
+import com.google.cloud.bigquery.{BigQuery, QueryResponse}
 import scalikejdbc._
 
 import scala.concurrent.duration._
@@ -14,13 +15,16 @@ class QueryExecutor(bigQuery: BigQuery, config: QueryConfig) {
   def execute(statement: SQLSyntax): WrappedQueryResponse = {
 
     val builder = QueryRequestBuilder(statement)
-      .setMaxWaitTime(30.minutes.toMillis) // TODO: make configurable
       .setUseLegacySql(config.useLegacySql)
       .setUseQueryCache(config.useQueryCache)
 
+    val queryOptions = Seq(
+      QueryOption.of(QueryResultsOption.maxWaitTime(30.minutes.toMillis)) // TODO: make configurable
+    )
+
     val request = builder.build()
 
-    val response = bigQuery.query(request)
+    val response = bigQuery.query(request, queryOptions: _*)
 
     val rs = new BqResultSet(response.getResult)
 

--- a/src/test/scala/com/google/cloud/bigquery/MockUtil.scala
+++ b/src/test/scala/com/google/cloud/bigquery/MockUtil.scala
@@ -37,14 +37,14 @@ object MockUtil {
       // TODO: case Struct() =>
     }
 
-    new FieldValue(attribute, underlying)
+    FieldValue.of(attribute, underlying)
   }
 
   def queryResultFromSeq(source: Seq[Seq[FieldValue]], schema: Schema): QueryResult = {
     val builder = QueryResult.newBuilder()
 
     builder.setSchema(schema)
-    builder.setResults(source.map(_.asJava).asJava)
+    builder.setResults(source.map(seq => FieldValueList.of(seq.asJava, schema.getFields)).asJava)
 
     builder.build()
   }

--- a/src/test/scala/scalikejdbc/bigquery/BqResultSetTest.scala
+++ b/src/test/scala/scalikejdbc/bigquery/BqResultSetTest.scala
@@ -1,8 +1,8 @@
 package scalikejdbc.bigquery
 
-import java.time.{ZoneId, ZonedDateTime, LocalTime, LocalDate}
+import java.time.{LocalDate, LocalTime, ZoneId, ZonedDateTime}
 
-import com.google.cloud.bigquery.{Field, Schema, MockUtil}
+import com.google.cloud.bigquery.{Field, LegacySQLTypeName, MockUtil, Schema}
 import org.scalatest.FlatSpec
 
 class BqResultSetTest extends FlatSpec {
@@ -13,7 +13,7 @@ class BqResultSetTest extends FlatSpec {
     val row2 = Seq(BqParameter.String("second")).map(MockUtil.fieldValueFromParameter(_))
     val row3 = Seq(BqParameter.String("third")).map(MockUtil.fieldValueFromParameter(_))
 
-    val schema = Schema.newBuilder().addField(Field.of("name", Field.Type.string())).build()
+    val schema = Schema.of(Field.of("name", LegacySQLTypeName.STRING));
     val queryResult = MockUtil.queryResultFromSeq(Seq(row1, row2, row3), schema)
 
     val resultSet = new BqResultSet(queryResult)
@@ -38,16 +38,18 @@ class BqResultSetTest extends FlatSpec {
       BqParameter.Timestamp(ZonedDateTime.of(2017, 3, 22, 19, 58, 0, 0, ZoneId.of("Asia/Tokyo")))
     ).map(MockUtil.fieldValueFromParameter(_))
 
-    val schema = Schema.newBuilder().setFields(
-      Field.of("int64_column", Field.Type.integer()),
-      Field.of("float64_column", Field.Type.floatingPoint()),
-      Field.of("bool_column", Field.Type.bool()),
-      Field.of("string_column", Field.Type.string()),
-      Field.of("bytes_column", Field.Type.bytes()),
-      Field.of("date_column", Field.Type.string()),
-      Field.of("time_column", Field.Type.string()),
-      Field.of("timestamp_column", Field.Type.timestamp())
-    ).build()
+    val fields = Seq(
+      Field.of("int64_column", LegacySQLTypeName.INTEGER),
+      Field.of("float64_column", LegacySQLTypeName.FLOAT),
+      Field.of("bool_column", LegacySQLTypeName.BOOLEAN),
+      Field.of("string_column", LegacySQLTypeName.STRING),
+      Field.of("bytes_column", LegacySQLTypeName.BYTES),
+      Field.of("date_column", LegacySQLTypeName.STRING),
+      Field.of("time_column", LegacySQLTypeName.STRING),
+      Field.of("timestamp_column", LegacySQLTypeName.TIMESTAMP)
+    )
+
+    val schema = Schema.of(fields: _*)
 
     val queryResult = MockUtil.queryResultFromSeq(Seq(row), schema)
 


### PR DESCRIPTION
This PR is intended to just bump up BigQuery SDK to `0.30.0-beta` so I didn't touched class structures and so on as I can.

NOTE: This branch passed integration tests and unit tests. However this version is not yet put into production.

---

~~Integration test on CI is failing...  I'll investigate lator.~~
https://github.com/ocadaruma/scalikejdbc-bigquery/pull/13/files
Perhaps this is intended behavior.