### PR TITLE
feat: bump up google-cloud-bigquery

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ configs(IntegrationTest)
 inConfig(IntegrationTest)(Defaults.itSettings)
 
 val scalikejdbcVersion = "3.0.0"
-val googleCloudVersion = "0.30.0-beta"
+val googleCloudVersion = "1.41.0"
 
 libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc" % scalikejdbcVersion % "provided,it,test",

--- a/src/it/scala/scalikejdbc/bigquery/QueryDSLIntegration.scala
+++ b/src/it/scala/scalikejdbc/bigquery/QueryDSLIntegration.scala
@@ -8,33 +8,35 @@ import scalikejdbc._
 
 class QueryDSLIntegration extends FlatSpec with BigQueryFixture {
 
-  //========================
-  // Suppose that tables and rows like following exist in DataSet:"scalikejdbc_bigquery_integration".
-  //
-  //     create table post (
-  //       id INT64,
-  //       body STRING,
-  //       posted_at TIMESTAMP,
-  //     );
-  //
-  //     create table tag (
-  //       id INT64,
-  //       post_id INT64,
-  //       name STRING
-  //     );
-  //
-  //     insert into post(id, body, posted_at) values (1, 'first post about jvm languages', '2017-03-23T10:00:00.000000+0000')
-  //     insert into tag(id, post_id, name) values (1, 1, 'java');
-  //     insert into tag(id, post_id, name) values (2, 1, 'scala');
-  //
-  //     insert into post(id, body, posted_at) values (2, 'second post', '2017-03-24T10:00:00.000000+0000')
-  //
-  //     insert into post(id, body, posted_at) values (3, 'third post about lightweight languages', '2017-03-25T10:00:00.000000+0000')
-  //     insert into tag(id, post_id, name) values (3, 3, 'ruby');
-  //     insert into tag(id, post_id, name) values (4, 3, 'python');
-  //     insert into tag(id, post_id, name) values (5, 3, 'perl');
-  //
-  //========================
+  /* ========================
+  Suppose that tables and rows like following exist in DataSet:"scalikejdbc_bigquery_integration".
+
+  create table scalikejdbc_bigquery_integration.post (
+    id INT64,
+    body STRING,
+    posted_at TIMESTAMP
+  );
+
+  create table scalikejdbc_bigquery_integration.tag (
+    id INT64,
+    post_id INT64,
+    name STRING
+  );
+
+  insert into scalikejdbc_bigquery_integration.post (id, body, posted_at) values
+    (1, 'first post about jvm languages', '2017-03-23T10:00:00.000000'),
+    (2, 'second post', '2017-03-24T10:00:00.000000'),
+    (3, 'third post about lightweight languages', '2017-03-25T10:00:00.000000');
+
+  insert into scalikejdbc_bigquery_integration.tag(id, post_id, name) values
+    (1, 1, 'java'),
+    (2, 1, 'scala'),
+    (3, 3, 'ruby'),
+    (4, 3, 'python'),
+    (5, 3, 'perl');
+
+  ======================== */
+
   it should "work correctly on standard SQL" in {
     val bigQuery = mkBigQuery()
     val queryConfig = QueryConfig()

--- a/src/main/scala/scalikejdbc/bigquery/BqResultSet.scala
+++ b/src/main/scala/scalikejdbc/bigquery/BqResultSet.scala
@@ -1,18 +1,18 @@
 package scalikejdbc.bigquery
 
-import java.io.{Reader, InputStream}
+import java.io.{InputStream, Reader}
 import java.math.BigDecimal
 import java.net.URL
 import java.sql.{Array => SqlArray, _}
-import java.time.{LocalDate, LocalTime, Instant}
+import java.time.{Instant, LocalDate, LocalTime}
 import java.util
 import java.util.Calendar
 
-import com.google.cloud.bigquery.{FieldValue, QueryResult}
+import com.google.cloud.bigquery.{FieldValue, TableResult}
 
 import scala.collection.JavaConverters._
 
-class BqResultSet(underlying: QueryResult) extends ResultSet {
+class BqResultSet(underlying: TableResult) extends ResultSet {
 
   private[this] val resultIterator: Iterator[Seq[FieldValue]] = underlying.iterateAll().asScala.map(_.asScala).iterator
   private[this] val columnNameIndexMap: Map[String, Int] = underlying.getSchema.getFields.asScala.zipWithIndex

--- a/src/main/scala/scalikejdbc/bigquery/Response.scala
+++ b/src/main/scala/scalikejdbc/bigquery/Response.scala
@@ -1,8 +1,8 @@
 package scalikejdbc.bigquery
 
-import com.google.cloud.bigquery.QueryResponse
+import com.google.cloud.bigquery.TableResult
 
 /**
  * Represents a response from BigQuery.
  */
-case class Response[A](result: A, underlying: QueryResponse)
+case class Response[A](result: A, underlying: TableResult)

--- a/src/test/scala/scalikejdbc/bigquery/BqResultSetTest.scala
+++ b/src/test/scala/scalikejdbc/bigquery/BqResultSetTest.scala
@@ -14,7 +14,7 @@ class BqResultSetTest extends FlatSpec {
     val row3 = Seq(BqParameter.String("third")).map(MockUtil.fieldValueFromParameter(_))
 
     val schema = Schema.of(Field.of("name", LegacySQLTypeName.STRING));
-    val queryResult = MockUtil.queryResultFromSeq(Seq(row1, row2, row3), schema)
+    val queryResult = MockUtil.tableResultFromSeq(Seq(row1, row2, row3), schema)
 
     val resultSet = new BqResultSet(queryResult)
 
@@ -51,7 +51,7 @@ class BqResultSetTest extends FlatSpec {
 
     val schema = Schema.of(fields: _*)
 
-    val queryResult = MockUtil.queryResultFromSeq(Seq(row), schema)
+    val queryResult = MockUtil.tableResultFromSeq(Seq(row), schema)
 
     val resultSet = new BqResultSet(queryResult)
 


### PR DESCRIPTION
NOTE: This PR has breaking change.
`Response#underlying ` changed `QueryResponse` to `TableResult`.
https://github.com/ocadaruma/scalikejdbc-bigquery/compare/master...sisisin:master#diff-ce268c1fe5d29f1639d577757f552c79R8

In `google-cloud-bigquery 1.41.0`, `QueryResponse` is internal API.
So, I change `QueryResponse` to `TableResult`.
