### PR TITLE
fix thrown NullPointerException when query result returns empty row

### DIFF
--- a/src/it/scala/scalikejdbc/bigquery/QueryDSLIntegration.scala
+++ b/src/it/scala/scalikejdbc/bigquery/QueryDSLIntegration.scala
@@ -139,4 +139,26 @@ class QueryDSLIntegration extends FlatSpec with BigQueryFixture {
 
     assert(result == 1L)
   }
+
+  it should "return empty result" in {
+    val bigQuery = mkBigQuery()
+    val queryConfig = QueryConfig()
+
+    val dataset = DatasetId.of(projectId(), "scalikejdbc_bigquery_integration")
+
+    val executor = new QueryExecutor(bigQuery, queryConfig)
+
+    import Post.p
+
+    val response = bq {
+      select(p.result.id).from(Post in dataset as p)
+        .where.isNull(p.id)
+    }
+      .map(_.long(p.resultName.id))
+      .single
+      .run(executor)
+
+    assert(response.result == None)
+  }
+
 }

--- a/src/main/scala/scalikejdbc/bigquery/BqResultSet.scala
+++ b/src/main/scala/scalikejdbc/bigquery/BqResultSet.scala
@@ -15,8 +15,11 @@ import scala.collection.JavaConverters._
 class BqResultSet(underlying: TableResult) extends ResultSet {
 
   private[this] val resultIterator: Iterator[Seq[FieldValue]] = underlying.iterateAll().asScala.map(_.asScala).iterator
-  private[this] val columnNameIndexMap: Map[String, Int] = underlying.getSchema.getFields.asScala.zipWithIndex
-    .map { case (field, index) => (field.getName, index) }.toMap
+
+  private[this] val columnNameIndexMap: Map[String, Int] = Option(underlying.getSchema)
+    .fold(Map.empty[String, Int]) {
+      _.getFields.asScala.zipWithIndex.map { case (field, index) => (field.getName, index) }.toMap
+    }
 
   private[this] var current: Seq[FieldValue] = null
 

--- a/src/test/scala/scalikejdbc/bigquery/BqResultSetTest.scala
+++ b/src/test/scala/scalikejdbc/bigquery/BqResultSetTest.scala
@@ -2,10 +2,16 @@ package scalikejdbc.bigquery
 
 import java.time.{LocalDate, LocalTime, ZoneId, ZonedDateTime}
 
-import com.google.cloud.bigquery.{Field, LegacySQLTypeName, MockUtil, Schema}
+import com.google.cloud.PageImpl
+import com.google.cloud.bigquery._
 import org.scalatest.FlatSpec
 
 class BqResultSetTest extends FlatSpec {
+
+  it should "be able to instantiate from null Schema" in {
+    val tableResult = MockUtil.tableResultFromSeq(Nil, null)
+    new BqResultSet(tableResult)
+  }
 
   it should "correctly traversable" in {
 


### PR DESCRIPTION
TableResult#getSchema returns null when query result is empty row.
so, I fixed set `columnNameIndexMap` empty.

see: https://github.com/GoogleCloudPlatform/google-cloud-java/blob/e4b526656bb1bf5eefd0ee578b7405147821225e/google-cloud-clients/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Job.java#L307